### PR TITLE
Added the option to provider storageClassName to the modelsVolume.pvc

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ modelsVolume:
     size: 6Gi
     accessModes:
     - ReadWriteOnce
+    # Optional
+    # storageClassName: ""
   auth:
     # Optional value for HTTP basic access authentication header
     basic: "" # 'username:password' base64 encoded

--- a/charts/local-ai/Chart.yaml
+++ b/charts/local-ai/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 0.1.0
 description: A Helm chart for LocalAI
 name: local-ai
 type: application
-version: 1.0.2
+version: 1.0.3

--- a/charts/local-ai/templates/models-pvc.yaml
+++ b/charts/local-ai/templates/models-pvc.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ template "local-ai.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
+  {{- if .Values.modelsVolume.pvc.storageClassName }}
+  storageClassName: {{ .Values.modelsVolume.pvc.storageClassName }}
+  {{- end }}
   accessModes: {{ .Values.modelsVolume.pvc.accessModes }}
   resources:
     requests:

--- a/charts/local-ai/values.yaml
+++ b/charts/local-ai/values.yaml
@@ -14,6 +14,8 @@ modelsVolume:
     size: 6Gi
     accessModes:
     - ReadWriteOnce
+    # Optional
+    # storageClassName: ""
   auth:
     # Optional value for HTTP basic access authentication header
     basic: "" # 'username:password' base64 encoded


### PR DESCRIPTION
* Because storageClasses differ between providers and the `default` class may not suffice I have added in storageClassName to the pvc.

I did not see any tests written, however I ran `helm lint` and passed:
```
==> Linting .
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
```