### PR TITLE
feat: add hostPath option for /models, reduce default threads

### DIFF
--- a/charts/local-ai/templates/deployment.yaml
+++ b/charts/local-ai/templates/deployment.yaml
@@ -101,10 +101,14 @@ spec:
           - mountPath: {{ .Values.deployment.env.modelsPath }}
             name: models
       volumes:
-      {{- if .Values.models.persistence.enabled }}
+      {{- if .Values.models.persistence.pvc.enabled }}
       - name: models
         persistentVolumeClaim:
           claimName: {{ template "local-ai.fullname" . }}
+      {{- else if .Values.models.persistence.hostPath.enabled }}
+      - name: models
+        hostPath:
+          path: {{ .Values.models.persistence.hostPath.path }}
       {{- else }}
       - name: models
         emptyDir: {}

--- a/charts/local-ai/values.yaml
+++ b/charts/local-ai/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 deployment:
   image: quay.io/go-skynet/local-ai:latest
   env:
-    threads: 14
+    threads: 4
     contextSize: 512
     modelsPath: "/models"
 
@@ -41,17 +41,25 @@ models:
     - url: "https://gpt4all.io/models/ggml-gpt4all-j.bin"
       # basicAuth: base64EncodedCredentials
 
-  # Persistent storage for models and prompt templates
+  # Persistent storage for models and prompt templates.
+  # PVC and HostPath are mutually exclusive. If both are enabled,
+  # PVC configuration takes precedence. If neither are enabled, ephemeral
+  # storage is used.
   persistence:
-    enabled: false
-    size: 6Gi
-    accessModes:
-      - ReadWriteOnce
+    pvc:
+      enabled: false
+      size: 6Gi
+      accessModes:
+        - ReadWriteOnce
 
-    annotations: {}
+      annotations: {}
 
-    # Optional
-    storageClass: ~
+      # Optional
+      storageClass: ~
+
+    hostPath:
+      enabled: false
+      path: "/models"
 
 service:
   type: ClusterIP


### PR DESCRIPTION
Useful for local deployment via kind, e.g.:

```bash
cat <<EOF > localai-kind-config.yaml
apiVersion: kind.x-k8s.io/v1alpha4
kind: Cluster
nodes:
- role: control-plane
  extraMounts:
  - hostPath: /path/to/go-skynet/LocalAI/models
    containerPath: /models
EOF

kind create cluster --config localai-kind-config.yaml
```

**Important**: this PR also reduces the default value for threads to something more reasonable. 14 is far too high in most cases and causes confusion with overclocking.