### PR TITLE
fix: update pvc values usage in PersistentVolumeClaim

### DIFF
--- a/charts/local-ai/Chart.yaml
+++ b/charts/local-ai/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 0.1.0
 description: A Helm chart for deploying LocalAI to a Kubernetes cluster
 name: local-ai
 type: application
-version: 2.1.0
+version: 2.1.1

--- a/charts/local-ai/templates/pvc-models.yaml
+++ b/charts/local-ai/templates/pvc-models.yaml
@@ -10,8 +10,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if .Values.models.persistence.pvc.storageClass }}
-  storageClassName: {{ .Values.models.persistence.pvc.storageClass }}
+  {{- with .Values.models.persistence.pvc.storageClass }}
+  storageClassName: {{ . }}
   {{- end }}
   accessModes:
   {{- range .Values.models.persistence.pvc.accessModes }}

--- a/charts/local-ai/templates/pvc-models.yaml
+++ b/charts/local-ai/templates/pvc-models.yaml
@@ -4,8 +4,7 @@ apiVersion: v1
 metadata:
   name: {{ template "local-ai.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
-  labels:
-    {{- include "local-ai.labels" . | nindent 4 }}
+  labels: {{ include "local-ai.labels" . | nindent 4 }}
   {{- with .Values.models.persistence.pvc.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/local-ai/templates/pvc-models.yaml
+++ b/charts/local-ai/templates/pvc-models.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.models.persistence.enabled }}
+{{- if .Values.models.persistence.pvc.enabled }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -7,18 +7,18 @@ metadata:
   labels:
     {{- include "local-ai.labels" . | nindent 4 }}
   annotations:
-    {{- if .Values.models.persistence.annotations }}
-    {{- toYaml .Values.models.persistence.annotations | nindent 4 }}
+    {{- with .Values.models.persistence.pvc.annotations }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-{{- if .Values.models.persistence.storageClass }}
-  storageClassName: {{ .Values.models.persistence.storageClass }}
+{{- if .Values.models.persistence.pvc.storageClass }}
+  storageClassName: {{ .Values.models.persistence.pvc.storageClass }}
   {{- end }}
   accessModes:
-  {{- range .Values.models.persistence.accessModes }}
+  {{- range .Values.models.persistence.pvc.accessModes }}
     - {{ . | quote }}
   {{- end }}
   resources:
     requests:
-      storage: {{ .Values.models.persistence.size | quote }}
+      storage: {{ .Values.models.persistence.pvc.size | quote }}
 {{- end }}

--- a/charts/local-ai/templates/pvc-models.yaml
+++ b/charts/local-ai/templates/pvc-models.yaml
@@ -6,10 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "local-ai.labels" . | nindent 4 }}
+  {{- with .Values.models.persistence.pvc.annotations }}
   annotations:
-    {{- with .Values.models.persistence.pvc.annotations }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
 {{- if .Values.models.persistence.pvc.storageClass }}
   storageClassName: {{ .Values.models.persistence.pvc.storageClass }}

--- a/charts/local-ai/templates/pvc-models.yaml
+++ b/charts/local-ai/templates/pvc-models.yaml
@@ -13,8 +13,8 @@ spec:
   {{- with .Values.models.persistence.pvc.storageClass }}
   storageClassName: {{ . }}
   {{- end }}
-  accessModes:
   {{- range .Values.models.persistence.pvc.accessModes }}
+  accessModes:
     - {{ . | quote }}
   {{- end }}
   resources:


### PR DESCRIPTION
## Issue

Incorrect paths to `models.persistence.pvc` values in the `PersistentVolumeClaim` template cause PersistentVolumeClaim to generate an error and fail to start the pod.

Ref: https://github.com/go-skynet/helm-charts/issues/16

## Changes:
* use correct path to pvc values - `.Values.models.persistence.pvc`;
* update some templates - use `with` instead of `if` for: `annotations` and `storageClassName`;
* improve `range` operator for `accessModes` - do not generate accessModes when value is empty.
* delete newline for labes and space traling `{{-` for that

## How to check

```bash
# should not generate pvc template and not add the name of PVC in Deployment
helm template test charts/local-ai/ --set models.persistence.pvc.enabled=false

# should generate pvc template and add the name of PVC in Deployment
helm template test charts/local-ai/ --set models.persistence.pvc.enabled=true
```