### PR TITLE
minor fixes to allow for other aws setups

### DIFF
--- a/charts/local-ai/templates/deployment.yaml
+++ b/charts/local-ai/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       initContainers:
         {{- if .Values.promptTemplates }}
         - name: prompt-templates
-          image: busybox
+          image: {{ .Values.deployment.prompt_templates.image }}
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -42,7 +42,7 @@ spec:
               name: models
         {{- end }}
         - name: download-model
-          image: busybox
+          image: {{ .Values.deployment.download_model.image }}
           command: ["/bin/sh", "-c"]
           args:
             - |

--- a/charts/local-ai/templates/service.yaml
+++ b/charts/local-ai/templates/service.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "local-ai.labels" . | nindent 4 }}
 {{- if .Values.service.annotations }}
   annotations:
-  {{ toYaml .Values.service.annotations | indent 4 }}
+  {{ toYaml .Values.service.annotations | nindent 4 }}
 {{- end }}
 spec:
   selector:

--- a/charts/local-ai/templates/service.yaml
+++ b/charts/local-ai/templates/service.yaml
@@ -13,6 +13,9 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "local-ai.name" . }}
   type: "{{ .Values.service.type }}"
+{{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+{{- end }}
   ports:
     - protocol: TCP
       port: {{ .Values.service.port }}

--- a/charts/local-ai/values.yaml
+++ b/charts/local-ai/values.yaml
@@ -69,6 +69,8 @@ models:
 
 service:
   type: ClusterIP
+  # If deferring to an internal only load balancer
+  # externalTrafficPolicy: Local
   port: 80
   annotations: {}
   # If using an AWS load balancer, you'll need to override the default 60s load balancer idle timeout

--- a/charts/local-ai/values.yaml
+++ b/charts/local-ai/values.yaml
@@ -6,6 +6,12 @@ deployment:
     threads: 4
     context_size: 512
   modelsPath: "/models"
+  download_model:
+    # To use cloud provided (eg AWS) image, provide it like: 1234356789.dkr.ecr.us-REGION-X.amazonaws.com/busybox
+    image: busybox
+  prompt_templates:
+    # To use cloud provided (eg AWS) image, provide it like: 1234356789.dkr.ecr.us-REGION-X.amazonaws.com/busybox
+    image: busybox
 
 resources:
   {}


### PR DESCRIPTION
As it was, you could not have multiple service annotations; I would get:

Error: YAML parse error on local-ai/templates/service.yaml: error converting YAML to JSON: yaml: line 13: did not find expected key

When I ran helm template, it was because the first annotation was indented extra.