### PR TITLE
add imagepullpolicy

### DIFF
--- a/charts/local-ai/templates/deployment.yaml
+++ b/charts/local-ai/templates/deployment.yaml
@@ -31,6 +31,7 @@ spec:
         {{- if .Values.promptTemplates }}
         - name: prompt-templates
           image: {{ .Values.deployment.prompt_templates.image }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -43,6 +44,7 @@ spec:
         {{- end }}
         - name: download-model
           image: {{ .Values.deployment.download_model.image }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -88,6 +90,7 @@ spec:
       containers:
         - name: {{ template "local-ai.fullname" . }}
           image: {{ .Values.deployment.image }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:

--- a/charts/local-ai/values.yaml
+++ b/charts/local-ai/values.yaml
@@ -12,6 +12,7 @@ deployment:
   prompt_templates:
     # To use cloud provided (eg AWS) image, provide it like: 1234356789.dkr.ecr.us-REGION-X.amazonaws.com/busybox
     image: busybox
+  pullPolicy: IfNotPresent
 
 resources:
   {}


### PR DESCRIPTION
Adds imagePullPolicy for containers

This PR is required for running in offline environments where images cannot be pulled on a host reboot.