### PR TITLE
Pull Policy Default in Values

### DIFF
--- a/charts/local-ai/values.yaml
+++ b/charts/local-ai/values.yaml
@@ -99,3 +99,7 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+image:
+  pullPolicy: IfNotPresent
+


### PR DESCRIPTION
Default template doesn't work

```
Error: INSTALLATION FAILED: template: local-ai/templates/deployment.yaml:47:37: executing "local-ai/templates/deployment.yaml" at <.Values.image.pullPolicy>: nil pointer evaluating interface {}.pullPolicy
```