### PR TITLE
imagePullSecrets would be specified at the pod spec level, not at the container level

### DIFF
--- a/charts/local-ai/templates/deployment.yaml
+++ b/charts/local-ai/templates/deployment.yaml
@@ -27,14 +27,14 @@ spec:
         checksum/config-prompt-templates: {{ include (print $.Template.BasePath "/configmap-prompt-templates.yaml") . | sha256sum }}
         {{- end }}
     spec:
+    {{- with .Values.deployment.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       initContainers:
         {{- if .Values.promptTemplates }}
         - name: prompt-templates
           image: {{ .Values.deployment.prompt_templates.image }}
-          {{- with .Values.deployment.imagePullSecrets }}
-          imagePullSecrets:
-          {{- toYaml . | nindent 12 }}
-          {{- end }}
           imagePullPolicy: {{ .Values.deployment.pullPolicy }}
           command: ["/bin/sh", "-c"]
           args:
@@ -48,10 +48,6 @@ spec:
         {{- end }}
         - name: download-model
           image: {{ .Values.deployment.download_model.image }}
-          {{- with .Values.deployment.imagePullSecrets }}
-          imagePullSecrets:
-          {{- toYaml . | nindent 12 }}
-          {{- end }}
           imagePullPolicy: {{ .Values.deployment.pullPolicy }}
           command: ["/bin/sh", "-c"]
           args:
@@ -98,10 +94,6 @@ spec:
       containers:
         - name: {{ template "local-ai.fullname" . }}
           image: {{ .Values.deployment.image }}
-          {{- with .Values.deployment.imagePullSecrets }}
-          imagePullSecrets:
-          {{- toYaml . | nindent 12 }}
-          {{- end }}
           imagePullPolicy: {{ .Values.deployment.pullPolicy }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
1. Currently imagePullSecrets are specified at containerlevel , and imagePullSecret is not applied to deployment with below warnings:

```
helm install release . --values values.yaml
W1122 12:26:54.913759   97726 warnings.go:70] unknown field "spec.template.spec.containers[0].imagePullSecrets"
W1122 12:26:54.913783   97726 warnings.go:70] unknown field "spec.template.spec.initContainers[0].imagePullSecrets"
NAME: release
LAST DEPLOYED: Wed Nov 22 12:26:54 2023
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
```

2. Added the fix to apply imagePullSecrets at pod spec level,After fix:

```
helm install release . --values values.yaml                                
NAME: release
LAST DEPLOYED: Wed Nov 22 12:31:26 2023
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
```

and deployment is updated with imagePullSecrets

```
kubectl get deploy release-local-ai -o yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  annotations:
    deployment.kubernetes.io/revision: "1"
    meta.helm.sh/release-name: release
    meta.helm.sh/release-namespace: default
  creationTimestamp: "2023-11-22T20:47:52Z"
  generation: 1
  labels:
    app.kubernetes.io/instance: release
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: local-ai
    app.kubernetes.io/version: "1.3"
    helm.sh/chart: local-ai-2.1.2
  name: release-local-ai
  namespace: default
  resourceVersion: "3582"
  uid: 1bfa8dfa-9c5c-4043-b8aa-6c8bf16816ff
spec:
  progressDeadlineSeconds: 600
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app.kubernetes.io/instance: release
      app.kubernetes.io/name: local-ai
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  template:
    metadata:
      creationTimestamp: null
      labels:
        app.kubernetes.io/instance: release
        app.kubernetes.io/name: local-ai
      name: release-local-ai
    spec:
      containers:
      - env:
        - name: CONTEXT_SIZE
          value: "512"
        - name: THREADS
          value: "4"
        - name: MODELS_PATH
          value: /models
        image: quay.io/go-skynet/local-ai:latest
        imagePullPolicy: IfNotPresent
        name: release-local-ai
        resources: {}
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        volumeMounts:
        - mountPath: /models
          name: models
      dnsPolicy: ClusterFirst
      imagePullSecrets:
      - name: docker-registry-secret
      initContainers:
      - args:
        - |
          MODEL_DIR=/models
          FORCE_DOWNLOAD=false
          URLS=""

          mkdir -p "$MODEL_DIR"

          # Split urls on commas
          echo "$URLS" | awk -F, '{for (i=1; i<=NF; i++) print $i}' | while read -r line; do
              url=$(echo "$line" | awk '{print $1}')
              auth=$(echo "$line" | awk '{print $2}')

              if [ -n "$url" ]; then
                  filename=$(basename "$url" .bin)

                  if [ "$FORCE_DOWNLOAD" = false ] && [ -f "$MODEL_DIR/$filename" ]; then
                      echo "File $filename already exists. Skipping download."
                      continue
                  fi

                  rm -f "$MODEL_DIR/$filename"

                  echo "Downloading $filename"

                  if [ -n "$auth" ]; then
                      wget --header "Authorization: Basic $auth" "$url" -O "$MODEL_DIR/$filename"
                  else
                      wget "$url" -O "$MODEL_DIR/$filename"
                  fi

                  if [ "$?" -ne 0 ]; then
                      echo "Download failed."
                  else
                      echo "Download completed."
                  fi
              fi
          done
        command:
        - /bin/sh
        - -c
        image: busybox
        imagePullPolicy: IfNotPresent
        name: download-model
        resources: {}
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        volumeMounts:
        - mountPath: /models
          name: models
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext: {}
      terminationGracePeriodSeconds: 30
      volumes:
      - emptyDir: {}
        name: models
      - configMap:
          defaultMode: 420
          name: release-local-ai-prompt-templates
        name: prompt-templates
status:
  availableReplicas: 1
  conditions:
  - lastTransitionTime: "2023-11-22T20:47:54Z"
    lastUpdateTime: "2023-11-22T20:47:54Z"
    message: Deployment has minimum availability.
    reason: MinimumReplicasAvailable
    status: "True"
    type: Available
  - lastTransitionTime: "2023-11-22T20:47:52Z"
    lastUpdateTime: "2023-11-22T20:47:54Z"
    message: ReplicaSet "release-local-ai-6c8b454879" has successfully progressed.
    reason: NewReplicaSetAvailable
    status: "True"
    type: Progressing
  observedGeneration: 1
  readyReplicas: 1
  replicas: 1
  updatedReplicas: 1
  ```