### PR TITLE
Update deployment.yaml

### DIFF
--- a/charts/local-ai/templates/deployment.yaml
+++ b/charts/local-ai/templates/deployment.yaml
@@ -107,6 +107,8 @@ spec:
           volumeMounts:
           - mountPath: {{ .Values.deployment.modelsPath }}
             name: models
+          - mountPath: /tmp/generated/images
+            name: sd-generated-images
       volumes:
       {{- if .Values.models.persistence.pvc.enabled }}
       - name: models
@@ -120,6 +122,8 @@ spec:
       - name: models
         emptyDir: {}
       {{- end }}
+      - names: sd-generated-images
+        emptyDir: {}
       - name: prompt-templates
         configMap:
           name: {{ template "local-ai.fullname" . }}-prompt-templates


### PR DESCRIPTION
add empty-dir for SD at /tmp/generated/images
I haven't tested this change explicitly but adding this empty-dir to the deployment after the fact fixes the "{"error":{"code":500,"message":"open /tmp/generated/images/{filename}: no such file or directory","type":""}}"