### PR TITLE
Err413 mitigation

### DIFF
--- a/charts/local-ai/values.yaml
+++ b/charts/local-ai/values.yaml
@@ -106,6 +106,7 @@ ingress:
   enabled: false
   className: ""
   annotations:
+    {}
     # nginx.ingress.kubernetes.io/proxy-body-size: "25m" # This value determines the maxmimum uploadable file size
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"

--- a/charts/local-ai/values.yaml
+++ b/charts/local-ai/values.yaml
@@ -106,7 +106,7 @@ ingress:
   enabled: false
   className: ""
   annotations:
-    {}
+    # nginx.ingress.kubernetes.io/proxy-body-size: "25m" # This value determines the maxmimum uploadable file size
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:


### PR DESCRIPTION
default `nginx.ingress.kubernetes.io/proxy-body-size` has been seen to prevent upload of images and audio for llava and whisper, 1 line update to values template for explicit note of this setting