### PR TITLE
Update values.yaml with better defaults

### DIFF
--- a/charts/local-ai/values.yaml
+++ b/charts/local-ai/values.yaml
@@ -112,14 +112,14 @@ persistence:
   models: 
     enabled: true
     annotations: {}
-    storageClass: hostPath
+    storageClass: "" # Use default storage class
     accessModes: ReadWriteMany
     size: 10Gi
     globalMount: /models
   output:
     enabled: true
     annotations: {}
-    storageClass: hostPath
+    storageClass: "" # Use default storage class
     accessModes: ReadWriteMany
     size: 5Gi
     globalMount: /tmp/generated
@@ -128,7 +128,7 @@ service:
   type: ClusterIP
   # If deferring to an internal only load balancer
   # externalTrafficPolicy: Local
-  port: 80
+  port: 8080
   annotations: {}
   # If using an AWS load balancer, you'll need to override the default 60s load balancer idle timeout
   # service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "1200"

--- a/charts/local-ai/values.yaml
+++ b/charts/local-ai/values.yaml
@@ -128,7 +128,7 @@ service:
   type: ClusterIP
   # If deferring to an internal only load balancer
   # externalTrafficPolicy: Local
-  port: 8080
+  port: 80
   annotations: {}
   # If using an AWS load balancer, you'll need to override the default 60s load balancer idle timeout
   # service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "1200"


### PR DESCRIPTION
Currently the Helm Chart does not work, as the expected container port is 8080 and not 80. Furthermore the chart uses the "hostPath" as a storage class, which I do not think is prefered, as setting this value to and empty string would instead use the default storage class, which makes things easier for folks.