### PR TITLE
Bugfix/update model url templating

### DIFF
--- a/charts/local-ai/templates/deployment.yaml
+++ b/charts/local-ai/templates/deployment.yaml
@@ -2,8 +2,9 @@
 {{- $urls := "" -}}
 {{- $rootPersistence := .Values.persistence }}
 {{- range $idx, $model := .Values.models.list }}
-{{- $urls = printf "%s%s %s," $urls $model.url ($model.basicAuth | default "") | trimSuffix "," | trim }}
+{{- $urls = printf "%s%s %s," $urls $model.url ($model.basicAuth | default "") }}
 {{- end }}
+{{- $urls = $urls | trimSuffix "," | trim }}
 
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/local-ai/templates/deployment.yaml
+++ b/charts/local-ai/templates/deployment.yaml
@@ -2,7 +2,7 @@
 {{- $urls := "" -}}
 {{- $rootPersistence := .Values.persistence }}
 {{- range $idx, $model := .Values.models.list }}
-{{- $urls = printf "%s%s %s," $urls $model.url ($model.basicAuth | default "") }}
+{{- $urls = printf "%s%s %s," $urls $model.url ($model.basicAuth | default "") | trimSuffix "," | trim }}
 {{- end }}
 
 apiVersion: apps/v1
@@ -140,7 +140,7 @@ spec:
 
               validate_url() {
                   local url=$1
-                  local regex='^(https?|ftp)://[a-zA-Z0-9.-]+(:[a-zA-Z0-9.-]+)?(/[a-zA-Z0-9.-]*)*$'
+                  local regex='^(https?|ftp):\/\/[a-zA-Z0-9.-_]+(:[a-zA-Z0-9.-]+)?(\/[a-zA-Z0-9._-]*)*$'
                   if [[ $url =~ $regex ]]; then
                       return 0 # URL is valid
                   else


### PR DESCRIPTION
This Pull Request updates two simple parts of the deployment.yaml template to support this chart:

1. The urls in the `list` value get concatenated into a CSV string as such: `{{- $urls = printf "%s%s %s," $urls $model.url ($model.basicAuth | default "") }}`. This would cause errors as it would leave a trailing comma at the end of the CSV string and cause the url to be invalid. I fix this by adding a template function to trim the suffix of the string from any commas and then trimming whitespace.
2. The regex to validate the url did not consider underscores as an option in the regex matching. Consider the following file uri in the goskynet/model-gallery (https://github.com/go-skynet/model-gallery/blob/main/mixtral-Q6.yaml#L42). This change will allow underscores as valid urls moving forward.

If I have misunderstood any parts of how to use this chart and appropriately set values, please feel free to respond and reject this Pull Request. But this was the only way I was able to get my helm chart to work.