### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ cat <<EOF > values.yaml
 replicaCount: 1
 
 deployment:
-  image: quay.io/go-skynet/local-ai:latest
+  image:
+    repository: quay.io/go-skynet/local-ai
+    tag: latest
   env:
     threads: 4
     context_size: 512


### PR DESCRIPTION
## Fix: Update installation instructions in README.md

**Changes:**

- Updated the README.md file to clarify the correct way to define the `image` value in `values.yaml`.

**Error:**
```
$helm install local-ai go-skynet/local-ai -f values.yaml

coalesce.go:220: warning: cannot overwrite table with non table for local-ai.deployment.image (map[repository:quay.io/go-skynet/local-ai tag:latest])
Error: INSTALLATION FAILED: template: local-ai/templates/deployment.yaml:259:28: executing "local-ai/templates/deployment.yaml" at <.Values.deployment.image.repository>: can't evaluate field repository in type interface {}
```


**Fixes:**

- Fixes issue where Helm installation fails due to incorrect installation instructions in README.md.

**Verification:**

- Confirmed that the updated instructions in the README.md file allow for successful Helm installation.