### PR TITLE
Various fixes (default values, pvcs and others)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ cat <<EOF > values.yaml
 replicaCount: 1
 
 deployment:
-  image: quay.io/go-skynet/local-ai:latest
+  image: quay.io/go-skynet/local-ai
+  tag: latest
   env:
     threads: 4
     context_size: 512

--- a/charts/local-ai/Chart.yaml
+++ b/charts/local-ai/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 1.40
 description: A Helm chart for deploying LocalAI to a Kubernetes cluster
 name: local-ai
 type: application
-version: 3.3.1
+version: 3.4.0

--- a/charts/local-ai/templates/_pvc.yaml
+++ b/charts/local-ai/templates/_pvc.yaml
@@ -19,8 +19,9 @@ metadata:
   annotations: {{- toYaml . | nindent 4 -}}
   {{- end }}
 spec:
-  accessModes:
-    - {{ required "accessMode is required for PVC" $pvcObject.accessMode | quote }}
+  {{- with required "accessModes is required for PVC" $pvcObject.accessModes }}
+  accessModes: {{- toYaml . | nindent 4 -}}
+  {{- end }}
   resources:
     requests:
       storage: {{ required "size is required for PVC" $pvcObject.size | quote }}

--- a/charts/local-ai/templates/deployment.yaml
+++ b/charts/local-ai/templates/deployment.yaml
@@ -1,9 +1,5 @@
 # yamllint disable rule:line-length
-{{- $urls := "" -}}
 {{- $rootPersistence := .Values.persistence }}
-{{- range $idx, $model := .Values.models.list }}
-{{- $urls = printf "%s%s %s," $urls $model.url ($model.basicAuth | default "") }}
-{{- end }}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -121,89 +117,6 @@ spec:
               {{- end }}
             {{- end }}
         {{- end }}
-        - name: download-model
-          image: {{ .Values.deployment.download_model.image }}
-          imagePullPolicy: {{ .Values.deployment.pullPolicy }}
-          command: ["/bin/sh", "-c"]
-          args:
-            - |
-              MODEL_DIR={{ .Values.deployment.modelsPath }}
-              FORCE_DOWNLOAD={{ .Values.models.forceDownload }}
-              URLS="{{ $urls }}"
-              LOCK_DIR=/tmp/model-download-locks
-
-              mkdir -p "$MODEL_DIR"
-              mkdir -p "$LOCK_DIR"
-              mkdir -p "/tmp/generated/images"
-              mkdir -p "/tmp/generated/audio"
-              rm -rf "/models/lost+found"
-
-              validate_url() {
-                  local url=$1
-                  local regex='^(https?|ftp)://[a-zA-Z0-9.-]+(:[a-zA-Z0-9.-]+)?(/[a-zA-Z0-9.-]*)*$'
-                  if [[ $url =~ $regex ]]; then
-                      return 0 # URL is valid
-                  else
-                      return 1 # URL is invalid
-                  fi
-              }
-
-              echo "List of URLs:"
-              echo "$URLS"
-
-              echo "$URLS" | awk -F, '{for (i=1; i<=NF; i++) print $i}' | while read -r line; do
-                  url=$(echo "$line" | awk '{print $1}')
-                  auth=$(echo "$line" | awk '{print $2}')
-                  full_filename=$(basename "$url" .bin)
-                  short_filename=$(echo "$full_filename" | cut -c1-20)
-                  hash=$(echo "$full_filename" | sha256sum | cut -c1-12)
-                  filename="${short_filename}_${hash}"
-                  lockfile="$LOCK_DIR/$filename.lock"
-
-                  # Validate URL
-                  if ! validate_url "$url"; then
-                      echo "Invalid URL: $url. Skipping download."
-                      continue
-                  fi
-
-                  if [ -e "$MODEL_DIR/$filename" ]; then
-                      echo "File $filename already exists. Skipping download."
-                      continue
-                  fi
-
-                  if [ -e "$lockfile" ]; then
-                      echo "Another pod is downloading $filename. Waiting for download to complete."
-                      while [ -e "$lockfile" ]; do sleep 1; done
-                      continue
-                  fi
-
-                  touch "$lockfile"
-
-                  echo "Downloading $filename"
-                  if [ -n "$auth" ]; then
-                      wget --header "Authorization: Basic $auth" "$url" -O "$MODEL_DIR/$filename"
-                  else
-                      wget "$url" -O "$MODEL_DIR/$filename"
-                  fi
-
-                  if [ "$?" -ne 0 ]; then
-                      echo "Download failed."
-                      rm -f "$lockfile"
-                      exit 1
-                  else
-                      echo "Download completed."
-                      rm -f "$lockfile"
-                  fi
-              done
-
-          volumeMounts:
-            {{- range $key, $pvc := $rootPersistence }}
-            {{- if $pvc.enabled }}
-            - name: {{ $key }}
-              mountPath: {{ $pvc.globalMount | default (print "/" $key) }}
-            {{- end }}
-            {{- end }}
-
       containers:
         # Sidecar containers from values.yaml
         {{- range .Values.sidecarContainers }}

--- a/charts/local-ai/templates/pvcs.yaml
+++ b/charts/local-ai/templates/pvcs.yaml
@@ -1,6 +1,6 @@
 {{- range $key, $pvc := .Values.persistence -}}
   {{- if $pvc.enabled -}}
-    {{- $pvcObject := dict "name" (printf "%s-%s" (include "local-ai.fullname" $) $key) "accessMode" $pvc.accessModes "size" $pvc.size "storageClass" $pvc.storageClass "annotations" $pvc.annotations "labels" $pvc.labels -}}
+    {{- $pvcObject := dict "name" (printf "%s-%s" (include "local-ai.fullname" $) $key) "accessModes" $pvc.accessModes "size" $pvc.size "storageClass" $pvc.storageClass "annotations" $pvc.annotations "labels" $pvc.labels -}}
 
     {{- /* Include the PVC template */ -}}
     {{- include "local-ai.pvc" (dict "rootContext" $ "object" $pvcObject) | nindent 0 -}}

--- a/charts/local-ai/templates/service.yaml
+++ b/charts/local-ai/templates/service.yaml
@@ -18,6 +18,9 @@ spec:
 {{- end }}
   ports:
     - protocol: TCP
+      {{- if not (quote .Values.service.nodePort | empty) }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
       port: {{ .Values.service.port }}
       targetPort: 8080
       name: http

--- a/charts/local-ai/values.yaml
+++ b/charts/local-ai/values.yaml
@@ -2,8 +2,8 @@ replicaCount: 1
 
 deployment:
   image:
-    repository: quay.io/go-skynet/local-ai  # Example: "docker.io/myapp"
-    tag: latest    
+    repository: quay.io/go-skynet/local-ai
+    tag: latest    # Use the appropriate tag. E.g. for cpu only: "latest-cpu"
   env:
     threads: 4
     context_size: 512
@@ -99,14 +99,16 @@ persistence:
     enabled: true
     annotations: {}
     storageClass: "" # Use default storage class
-    accessModes: ReadWriteMany
+    accessModes:
+      - ReadWriteMany
     size: 10Gi
     globalMount: /models
   output:
     enabled: true
     annotations: {}
     storageClass: "" # Use default storage class
-    accessModes: ReadWriteMany
+    accessModes:
+      - ReadWriteMany
     size: 5Gi
     globalMount: /tmp/generated
 

--- a/charts/local-ai/values.yaml
+++ b/charts/local-ai/values.yaml
@@ -17,9 +17,6 @@ deployment:
   #       key: hf-token
 
   modelsPath: "/models"
-  download_model:
-    # To use cloud provided (eg AWS) image, provide it like: 1234356789.dkr.ecr.us-REGION-X.amazonaws.com/busybox
-    image: busybox
   prompt_templates:
     # To use cloud provided (eg AWS) image, provide it like: 1234356789.dkr.ecr.us-REGION-X.amazonaws.com/busybox
     image: busybox
@@ -74,17 +71,6 @@ promptTemplates:
   #   ### Prompt:
   #   {{.Input}}
   #   ### Response:
-
-# Models to download at runtime
-models:
-  # Whether to force download models even if they already exist
-  forceDownload: false
-
-  # The list of URLs to download models from
-  # Note: the name of the file will be the name of the loaded model
-  list:
-  #  - url: "https://gpt4all.io/models/ggml-gpt4all-j.bin"
-      # basicAuth: base64EncodedCredentials
 
 initContainers: []
 # Example:

--- a/charts/local-ai/values.yaml
+++ b/charts/local-ai/values.yaml
@@ -115,6 +115,7 @@ service:
   # If deferring to an internal only load balancer
   # externalTrafficPolicy: Local
   port: 80
+  nodePort:
   annotations: {}
   # If using an AWS load balancer, you'll need to override the default 60s load balancer idle timeout
   # service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "1200"


### PR DESCRIPTION
because since this change it won't work:
- Values example in the README need to change to match [this change](https://github.com/go-skynet/helm-charts/commit/e4185af3edb678ccf53038507f0831b0167dc5a8#diff-5dd0d86d32826953119270bc3eaca9f2d22a791a9d63ecf654da4c42956c66edR231)
- PVC accessMode should be an array
- we shouldn't download models in init containers since that delays the starting of the pod with no reason. There is now a GUI for people to download the models they want. Otherwise there is still a mechanism to define an init container and download what they want.
- Allow the user to define the NodePort when the service is of type NodePort