### PR TITLE
(Feat) Adding args and command override to values.yaml 

### DIFF
--- a/charts/local-ai/templates/deployment.yaml
+++ b/charts/local-ai/templates/deployment.yaml
@@ -183,6 +183,17 @@ spec:
           {{- if .Values.deployment.secretEnv }}
             {{- toYaml .Values.deployment.secretEnv | nindent 12 }}
           {{- end}}
+          command:
+            {{- if .Values.deployment.command }}
+            {{- toYaml .Values.deployment.command | nindent 12 }}
+            {{- else }}
+            - "/bin/bash"
+            - "-c"
+            - "/build/entrypoint.sh"
+            {{- end }}
+            {{- if .Values.deployment.args }}
+            {{- toYaml .Values.deployment.args | nindent 12 }}
+            {{- end }}
           volumeMounts:
             {{- range $key, $pvc := $rootPersistence}}
               {{- if $pvc.enabled }}

--- a/charts/local-ai/values.yaml
+++ b/charts/local-ai/values.yaml
@@ -8,6 +8,11 @@ deployment:
     threads: 4
     context_size: 512
 
+  # # Override default command or args passed in
+  # command: ["/bin/sh", "-c", "/build/entrypoint.sh"]
+  # args:
+  #   - --p2p
+
   # # Inject Secrets into Environment:
   # secretEnv:
   # - name: HF_TOKEN


### PR DESCRIPTION
I could not see a way to modify the run command for the main container. This means that there is no way to enable p2p or anything else that requires command line flags.

Added a command and args entry to the values.yaml which appends or overrides to the command field in the deployment.yaml allowing the usages of additional flags when running.